### PR TITLE
fix esave

### DIFF
--- a/Arduino/TinyBasicPlus.ino
+++ b/Arduino/TinyBasicPlus.ino
@@ -1318,8 +1318,10 @@ esave:
 
     // copied from "List"
     list_line = findline();
-    while(list_line != program_end)
+    while(list_line != program_end) {
       printline();
+    }
+    outchar('\0');
 
     // go back to standard output, close the file
     outStream = kStreamSerial;


### PR DESCRIPTION
Ensured that a '\0' is written at the end of the esave, so eload doesn't hang if EEPROM contents were random before.
