### PR TITLE
Fix compilation in Linux

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,10 @@
 *.la
 *.a
 
+# Editor files
+*.swp
+*~
+
 # misc
 cli/TinyBasicPlus.cpp
 cli/tbp

--- a/cli/main.cpp
+++ b/cli/main.cpp
@@ -3,9 +3,11 @@
 #if defined(__MINGW32__ )
 #endif
 
-#ifdef __APPLE__
-#include <dirent.h>
-#include <sys/stat.h>
+#if __APPLE__ || __linux__
+#   include <dirent.h>
+#   include <sys/stat.h>
+#else
+#   error Needs fixing to compile on your system
 #endif
 
 /* these are used in the .ino */


### PR DESCRIPTION
I've made two minor changes to allow working on Linux.

Please review them and merge if you so consider.

I have no way to check it still works on OS X. To be strict the `#ifdef __APPLE__` should have been translated to `#if defined(__APPLE__) || __linux__` but most sources I've checked suggest that `__APPLE__` is defined to be true, so `#if __APPLE__ || __linux__` should work equally well.

Thanks,
  